### PR TITLE
fix: Ensure model selection checkmark persists across navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -150,6 +150,13 @@ export default function Home() {
     }
   }, [hasApiKey, apiKeyStatus, justDidReset])
 
+  // Ensure model load status is set correctly when model is selected
+  useEffect(() => {
+    if (hasModel && modelLoadStatus !== 'success') {
+      setModelLoadStatus('success')
+    }
+  }, [hasModel, modelLoadStatus])
+
   const handleApiKeyValidated = (isValid: boolean, key?: string) => {
     if (isValid && key) {
       setApiKeyStatus('success')


### PR DESCRIPTION
## Summary

Fixes issue where the green checkmark for AI model selection would disappear when navigating back to the model selection screen.

## Changes Made

- Added useEffect to set modelLoadStatus to 'success' when hasModel is true
- This ensures the green checkmark persists when navigating back to model selection
- Fix maintains the checkmark indicator across navigation state changes

## Testing

- Selected a model and navigated through workflow steps
- Returned to model selection screen - checkmark remains visible
- Checkmark persists correctly even after page refresh (when model is stored in session)

Fixes #26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `modelLoadStatus` to `success` via a new effect when `hasModel` is true, keeping the model selection checkmark persistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18af2bc1535f7b7af4c5a8196d6b1cc1cd3229d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->